### PR TITLE
routing

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { EventThumbnailComponent } from './events/event-thumbnail.component';
 import { EventsListComponent } from './events/events-list.component';
 import { EventService } from './events/shared/event.service';
 import { NavBarComponent } from './nav/navbar.component';
+import { CreateEventComponent } from './events/create-event.component';
 
 @NgModule({
   imports: [
@@ -22,6 +23,7 @@ import { NavBarComponent } from './nav/navbar.component';
     EventsListComponent,
     EventThumbnailComponent,
     EventDetailsComponent,
+    CreateEventComponent,
     NavBarComponent
   ],
   providers: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -5,16 +5,19 @@ import { RouterModule } from '@angular/router';
 import { ToastrService } from './common/toastr.service';
 import { appRoutes } from './routes';
 
+import {
+  EventThumbnailComponent,
+  EventDetailsComponent,
+  EventsListComponent,
+  EventService,
+  CreateEventComponent,
+  EventRouteActivator,
+  EventListResolver
+} from './events/index';
+
 import { EventsAppComponent } from './events-app.component';
-import { EventDetailsComponent } from './events/event-details/event-details.component';
-import { EventThumbnailComponent } from './events/event-thumbnail.component';
-import { EventsListComponent } from './events/events-list.component';
-import { EventService } from './events/shared/event.service';
 import { NavBarComponent } from './nav/navbar.component';
-import { CreateEventComponent } from './events/create-event.component';
 import { Error404Component } from './errors/404.component';
-import { EventRouteActivator } from './events/event-details/event-route-activator.service';
-import { EventListResolver } from './events/event-list-resolver.service';
 
 @NgModule({
   imports: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -32,8 +32,19 @@ import { EventRouteActivator } from './events/event-details/event-route-activato
   providers: [
     EventService,
     ToastrService,
-    EventRouteActivator
+    EventRouteActivator,
+    { 
+      provide: 'canDeactivateCreateEvent', 
+      useValue: checkDirtyState
+    }
   ],
   bootstrap: [EventsAppComponent]
 })
 export class AppModule { }
+
+export function checkDirtyState(component: CreateEventComponent){
+  if(component.isDirty){
+    return window.confirm('You have not saved this event, do you really want to cancel?');
+  }
+  return true;
+}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -14,6 +14,7 @@ import { NavBarComponent } from './nav/navbar.component';
 import { CreateEventComponent } from './events/create-event.component';
 import { Error404Component } from './errors/404.component';
 import { EventRouteActivator } from './events/event-details/event-route-activator.service';
+import { EventListResolver } from './events/event-list-resolver.service';
 
 @NgModule({
   imports: [
@@ -36,7 +37,8 @@ import { EventRouteActivator } from './events/event-details/event-route-activato
     { 
       provide: 'canDeactivateCreateEvent', 
       useValue: checkDirtyState
-    }
+    },
+    EventListResolver
   ],
   bootstrap: [EventsAppComponent]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,19 +1,27 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { RouterModule } from '@angular/router';
+
 import { ToastrService } from './common/toastr.service';
+import { appRoutes } from './routes';
 
 import { EventsAppComponent } from './events-app.component';
+import { EventDetailsComponent } from './events/event-details/event-details.component';
 import { EventThumbnailComponent } from './events/event-thumbnail.component';
 import { EventsListComponent } from './events/events-list.component';
 import { EventService } from './events/shared/event.service';
 import { NavBarComponent } from './nav/navbar.component';
 
 @NgModule({
-  imports: [BrowserModule],
+  imports: [
+    BrowserModule,
+    RouterModule.forRoot(appRoutes)
+  ],
   declarations: [
     EventsAppComponent,
     EventsListComponent,
     EventThumbnailComponent,
+    EventDetailsComponent,
     NavBarComponent
   ],
   providers: [

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,6 +12,8 @@ import { EventsListComponent } from './events/events-list.component';
 import { EventService } from './events/shared/event.service';
 import { NavBarComponent } from './nav/navbar.component';
 import { CreateEventComponent } from './events/create-event.component';
+import { Error404Component } from './errors/404.component';
+import { EventRouteActivator } from './events/event-details/event-route-activator.service';
 
 @NgModule({
   imports: [
@@ -24,11 +26,13 @@ import { CreateEventComponent } from './events/create-event.component';
     EventThumbnailComponent,
     EventDetailsComponent,
     CreateEventComponent,
-    NavBarComponent
+    NavBarComponent,
+    Error404Component
   ],
   providers: [
     EventService,
-    ToastrService
+    ToastrService,
+    EventRouteActivator
   ],
   bootstrap: [EventsAppComponent]
 })

--- a/src/app/errors/404.component.ts
+++ b/src/app/errors/404.component.ts
@@ -1,0 +1,16 @@
+import { Component } from '@angular/core'
+
+@Component({
+  template: `
+    <h1 class="errorMessage">404'd</h1>
+  `,
+  styles: [`
+    .errorMessage { 
+      margin-top:150px; 
+      font-size: 170px;
+      text-align: center; 
+    }`]
+})
+export class Error404Component{
+  constructor() { }
+}

--- a/src/app/events-app.component.ts
+++ b/src/app/events-app.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'events-app',
   template: `
     <nav-bar></nav-bar>
-    <events-list></events-list>
+    <router-outlet></router-outlet>
   `
 })
 export class EventsAppComponent {

--- a/src/app/events/create-event.component.ts
+++ b/src/app/events/create-event.component.ts
@@ -1,0 +1,22 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+
+@Component({
+    template: `
+        <h1>New Event</h1>
+        <hr>
+        <div class="col-m-6">
+            <h3>[Create Event Form will go here]</h3>
+            <br/>
+            <br/>
+            <button type="submit" class='btn btn-primary'>Save</button>
+            <button type="button" class='btn btn-default' (click)="cancel()">Cancel</button>
+        </div>
+    `
+})
+export class CreateEventComponent{
+    constructor(private router: Router) {}
+    cancel(){
+        this.router.navigate(['/events']);
+    }
+}

--- a/src/app/events/create-event.component.ts
+++ b/src/app/events/create-event.component.ts
@@ -15,7 +15,10 @@ import { Router } from '@angular/router';
     `
 })
 export class CreateEventComponent{
+    isDirty: boolean = true;
+
     constructor(private router: Router) {}
+    
     cancel(){
         this.router.navigate(['/events']);
     }

--- a/src/app/events/event-details/event-details.component.html
+++ b/src/app/events/event-details/event-details.component.html
@@ -1,0 +1,24 @@
+<div class='container'>
+    <img [src]="event?.imageUrl" [alt]="event?.name" class='event-image'>
+  
+    <div class="row">
+      <div class="col-md-11">
+        <h2>{{event?.name}} </h2>
+      </div>
+    </div>
+  
+    <div class="row">
+      <div class="col-md-6">
+        <div><strong>Date:</strong> {{event?.date}}</div>
+        <div><strong>Time:</strong> {{event?.time}}</div>
+        <div><strong>Price:</strong> ${{event?.price}}</div>
+      </div>
+      <div class="col-md-6">
+        <address>
+          <strong>Address:</strong><br />
+          {{event?.location?.address}}<br />
+          {{event?.location?.city}}, {{event?.location?.country}}
+        </address>
+      </div>
+    </div>
+  </div>

--- a/src/app/events/event-details/event-details.component.ts
+++ b/src/app/events/event-details/event-details.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { EventService } from '../shared/event.service';
 
 @Component({
@@ -11,9 +12,9 @@ import { EventService } from '../shared/event.service';
 export class EventDetailsComponent implements OnInit{
     event: any;
 
-    constructor(private eventService: EventService) { }
+    constructor(private eventService: EventService, private route: ActivatedRoute) { }
 
     ngOnInit(){
-        this.event = this.eventService.getEvent(1);
+        this.event = this.eventService.getEvent(+this.route.snapshot.params['id']);
     }
 }

--- a/src/app/events/event-details/event-details.component.ts
+++ b/src/app/events/event-details/event-details.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit } from '@angular/core';
+import { EventService } from '../shared/event.service';
+
+@Component({
+    templateUrl: './event-details.component.html',
+    styles: [`
+        .container { padding-left:20px; padding-right:20px; }
+        .event-image { height: 100px; }
+    `]
+})
+export class EventDetailsComponent implements OnInit{
+    event: any;
+
+    constructor(private eventService: EventService) { }
+
+    ngOnInit(){
+        this.event = this.eventService.getEvent(1);
+    }
+}

--- a/src/app/events/event-details/event-route-activator.service.ts
+++ b/src/app/events/event-details/event-route-activator.service.ts
@@ -1,0 +1,17 @@
+import { ActivatedRouteSnapshot, CanActivate, Router } from '@angular/router';
+import { Injectable } from '@angular/core';
+import { EventService } from '../shared/event.service';
+
+@Injectable()
+export class EventRouteActivator implements CanActivate{
+    constructor(private eventService: EventService, private router: Router){ }
+
+    canActivate(route: ActivatedRouteSnapshot){
+        const eventExists = !!this.eventService.getEvent(+route.params['id']);
+
+        if(!eventExists){
+            this.router.navigate(['/404']);
+        }
+        return eventExists;
+    }
+}

--- a/src/app/events/event-details/index.ts
+++ b/src/app/events/event-details/index.ts
@@ -1,0 +1,2 @@
+export * from './event-details.component';
+export * from './event-route-activator.service'

--- a/src/app/events/event-list-resolver.service.ts
+++ b/src/app/events/event-list-resolver.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@angular/core';
+import { Resolve } from '@angular/router';
+import { EventService } from './shared/event.service';
+import { map } from 'rxjs/operators';
+
+@Injectable()
+export class EventListResolver implements Resolve<any>{
+    constructor(private eventService: EventService){ }
+
+    resolve(){
+        return this.eventService.getEvents().pipe(map(events=> events));
+    }
+}

--- a/src/app/events/event-thumbnail.component.ts
+++ b/src/app/events/event-thumbnail.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
     selector: 'event-thumbnail',
     template: `
-        <div class='well hoverwell thumbnail'>
+        <div [routerLink]="['/events', event.id]" class='well hoverwell thumbnail'>
             <h2>{{event?.name}}</h2>
             <div>Date: {{event?.date}}</div>
             <div [ngClass]="getStartTimeClass()" [ngSwitch]="event?.time">

--- a/src/app/events/events-list.component.ts
+++ b/src/app/events/events-list.component.ts
@@ -3,7 +3,6 @@ import { EventService } from './shared/event.service';
 import { ToastrService } from '../common/toastr.service';
 
 @Component({
-  selector: 'events-list',
   template: `
       <div>
           <h1>Upcoming Angular Events</h1>

--- a/src/app/events/events-list.component.ts
+++ b/src/app/events/events-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit} from '@angular/core';
 import { EventService } from './shared/event.service';
 import { ToastrService } from '../common/toastr.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   template: `
@@ -19,11 +20,11 @@ import { ToastrService } from '../common/toastr.service';
   `
 })
 export class EventsListComponent implements OnInit{
-  events: any[] = [];
-  constructor(private eventService: EventService, private toastr: ToastrService){ }
+  events: any;
+  constructor(private eventService: EventService, private toastr: ToastrService, private route: ActivatedRoute){ }
 
   ngOnInit(){
-    this.events = this.eventService.getEvents();
+    this.events = this.route.snapshot.data['events'];
   }
 
   handleThumbnailClick(eventName: string){

--- a/src/app/events/index.ts
+++ b/src/app/events/index.ts
@@ -1,0 +1,7 @@
+export * from './create-event.component';
+export * from './event-thumbnail.component';
+export * from './event-list-resolver.service';
+export * from './events-list.component';
+
+export * from './shared/index';
+export * from './event-details/index';

--- a/src/app/events/shared/event.service.ts
+++ b/src/app/events/shared/event.service.ts
@@ -1,9 +1,19 @@
 import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
 
 @Injectable()
 export class EventService{
+  
     getEvents(){
-        return EVENTS;
+        let subject = new Subject(); //Subject is a type of observable (stream of values)
+        
+        //simulate an async call using a 100ms timeout
+        setTimeout(() => {
+          subject.next(EVENTS);
+          subject.complete();
+        }, 100);
+
+        return subject;
     }
 
     getEvent(id: number){

--- a/src/app/events/shared/event.service.ts
+++ b/src/app/events/shared/event.service.ts
@@ -5,6 +5,10 @@ export class EventService{
     getEvents(){
         return EVENTS;
     }
+
+    getEvent(id: number){
+      return EVENTS.find(event => event.id === id);
+    }
 }
 
 const EVENTS = [

--- a/src/app/events/shared/index.ts
+++ b/src/app/events/shared/index.ts
@@ -1,0 +1,1 @@
+export * from './event.service';

--- a/src/app/nav/navbar.component.html
+++ b/src/app/nav/navbar.component.html
@@ -25,7 +25,7 @@
         <div class="navbar-header navbar-right">
           <ul class="nav navbar-nav">
             <li>
-              <a>Welcome John</a>
+              <a [routerLink]="['user/profile']">Welcome John</a>
             </li>
           </ul>
         </div>

--- a/src/app/nav/navbar.component.html
+++ b/src/app/nav/navbar.component.html
@@ -7,7 +7,7 @@
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
           <li>
-            <a >All Events</a>
+            <a [routerLink]="['/events']">All Events</a>
           </li>
           <li><a href="">Create Event</a></li>
           <li class="dropdown">

--- a/src/app/nav/navbar.component.html
+++ b/src/app/nav/navbar.component.html
@@ -9,7 +9,7 @@
           <li>
             <a [routerLink]="['/events']">All Events</a>
           </li>
-          <li><a href="">Create Event</a></li>
+          <li><a [routerLink]="['/events/new']">Create Event</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" >
               Events

--- a/src/app/nav/navbar.component.html
+++ b/src/app/nav/navbar.component.html
@@ -7,9 +7,9 @@
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
           <li>
-            <a [routerLink]="['/events']">All Events</a>
+            <a [routerLink]="['/events']" routerLinkActive='active' [routerLinkActiveOptions]="{exact: true}">All Events</a>
           </li>
-          <li><a [routerLink]="['/events/new']">Create Event</a></li>
+          <li><a [routerLink]="['/events/new']" routerLinkActive='active'>Create Event</a></li>
           <li class="dropdown">
             <a href="#" class="dropdown-toggle" data-toggle="dropdown" >
               Events

--- a/src/app/nav/navbar.component.ts
+++ b/src/app/nav/navbar.component.ts
@@ -4,6 +4,7 @@ import { Component } from '@angular/core';
     selector: 'nav-bar',
     templateUrl: './navbar.component.html',
     styles: [`
+        li > a.active { color: #F97924; }
         .nav.navbar-nav {font-size: 15px;}
         #searchForm {margin-right: 100px;}
         @media (max-width: 1200px) {#searchForm {display: none;}}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
+import { CreateEventComponent } from './events/create-event.component';
 import { EventDetailsComponent } from "./events/event-details/event-details.component";
 import { EventsListComponent } from "./events/events-list.component";
 
 export const appRoutes: Routes = [
     { path: 'events', component: EventsListComponent },
+    { path: 'events/new', component: CreateEventComponent },
     { path: 'events/:id', component: EventDetailsComponent },
     { path: '', redirectTo: '/events', pathMatch: 'full' }
 ]

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -3,10 +3,11 @@ import { Error404Component } from './errors/404.component';
 import { CreateEventComponent } from './events/create-event.component';
 import { EventDetailsComponent } from "./events/event-details/event-details.component";
 import { EventRouteActivator } from './events/event-details/event-route-activator.service';
+import { EventListResolver } from './events/event-list-resolver.service';
 import { EventsListComponent } from "./events/events-list.component";
 
 export const appRoutes: Routes = [
-    { path: 'events', component: EventsListComponent },
+    { path: 'events', component: EventsListComponent, resolve: {events: EventListResolver} },
     { path: 'events/new', component: CreateEventComponent, canDeactivate: ['canDeactivateCreateEvent'] },
     { path: 'events/:id', component: EventDetailsComponent, canActivate: [EventRouteActivator] },
     { path: '404', component: Error404Component },

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+import { EventDetailsComponent } from "./events/event-details/event-details.component";
+import { EventsListComponent } from "./events/events-list.component";
+
+export const appRoutes: Routes = [
+    { path: 'events', component: EventsListComponent },
+    { path: 'events/:id', component: EventDetailsComponent },
+    { path: '', redirectTo: '/events', pathMatch: 'full' }
+]

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -7,7 +7,7 @@ import { EventsListComponent } from "./events/events-list.component";
 
 export const appRoutes: Routes = [
     { path: 'events', component: EventsListComponent },
-    { path: 'events/new', component: CreateEventComponent },
+    { path: 'events/new', component: CreateEventComponent, canDeactivate: ['canDeactivateCreateEvent'] },
     { path: 'events/:id', component: EventDetailsComponent, canActivate: [EventRouteActivator] },
     { path: '404', component: Error404Component },
     { path: '', redirectTo: '/events', pathMatch: 'full' }

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,11 +1,14 @@
 import { Routes } from '@angular/router';
+import { Error404Component } from './errors/404.component';
 import { CreateEventComponent } from './events/create-event.component';
 import { EventDetailsComponent } from "./events/event-details/event-details.component";
+import { EventRouteActivator } from './events/event-details/event-route-activator.service';
 import { EventsListComponent } from "./events/events-list.component";
 
 export const appRoutes: Routes = [
     { path: 'events', component: EventsListComponent },
     { path: 'events/new', component: CreateEventComponent },
-    { path: 'events/:id', component: EventDetailsComponent },
+    { path: 'events/:id', component: EventDetailsComponent, canActivate: [EventRouteActivator] },
+    { path: '404', component: Error404Component },
     { path: '', redirectTo: '/events', pathMatch: 'full' }
 ]

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,10 +1,13 @@
 import { Routes } from '@angular/router';
+import {
+    EventDetailsComponent,
+    EventRouteActivator,
+    EventListResolver,
+    EventsListComponent,
+    CreateEventComponent
+} from './events/index';
 import { Error404Component } from './errors/404.component';
-import { CreateEventComponent } from './events/create-event.component';
-import { EventDetailsComponent } from "./events/event-details/event-details.component";
-import { EventRouteActivator } from './events/event-details/event-route-activator.service';
-import { EventListResolver } from './events/event-list-resolver.service';
-import { EventsListComponent } from "./events/events-list.component";
+
 
 export const appRoutes: Routes = [
     { path: 'events', component: EventsListComponent, resolve: {events: EventListResolver} },

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -11,5 +11,12 @@ export const appRoutes: Routes = [
     { path: 'events/new', component: CreateEventComponent, canDeactivate: ['canDeactivateCreateEvent'] },
     { path: 'events/:id', component: EventDetailsComponent, canActivate: [EventRouteActivator] },
     { path: '404', component: Error404Component },
-    { path: '', redirectTo: '/events', pathMatch: 'full' }
+    { path: '', redirectTo: '/events', pathMatch: 'full' },
+
+    //user feature module
+    { 
+        path: 'user', 
+        loadChildren: () => import('./user/user.module')
+            .then(m => m.UserModule)
+    }
 ]

--- a/src/app/user/profile.component.ts
+++ b/src/app/user/profile.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+
+@Component({
+    template: `
+        <h1>Edit Your Profile</h1>
+        <hr>
+        <div class="col-md-6">
+            <h3>[Edit profile form will go here]</h3>
+            <br />
+            <br />
+            <button type="submit" class="btn btn-primary">Save</button>
+            <button type="button" class="btn btn-default">Cancel</button>
+        </div>
+    `
+})
+export class ProfileComponent{
+
+}

--- a/src/app/user/user.module.ts
+++ b/src/app/user/user.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterModule } from '@angular/router';
+import { userRoutes } from './user.routes';
+import { ProfileComponent } from './profile.component';
+
+@NgModule({
+    imports: [
+        CommonModule,
+        RouterModule.forChild(userRoutes)
+    ],
+    declarations: [
+        ProfileComponent
+    ],
+    providers: [
+
+    ]
+})
+export class UserModule { }

--- a/src/app/user/user.routes.ts
+++ b/src/app/user/user.routes.ts
@@ -1,0 +1,5 @@
+import { ProfileComponent } from "./profile.component";
+
+export const userRoutes = [
+    {path: 'profile', component: ProfileComponent}
+]


### PR DESCRIPTION
- adds `/events/:id` route and gets event based off of the `id` route param (also guards for invalid `ids`)
- adds links to routes using `[routerLink]` in templates
- adds `/events/new` route and guards for `route deactivation` when new event isn't saved
- use a `resolver` for the `/events` route and access data through route
- style active navbar links using `routerLinkActive` and `[routerLinkActiveOptions]` in template
- adds a `feature module` for `/user/*` routes that is `lazy loaded`
- organize imports using the `barrels` [concept](https://basarat.gitbook.io/typescript/main-1/barrel)

this completes the 6th module `Routing and Navigating Pages`